### PR TITLE
Document and fix global admins

### DIFF
--- a/.test/test.yml
+++ b/.test/test.yml
@@ -2,14 +2,17 @@
 - name: Test Deployment
   hosts: all
   become: true
+  vars:
+    global_admins: &adm
+      # yamllint disable rule:line-length
+      - name: ftest
+        key: file:.test.pub
+      - name: utest
+        key: https://gitlab.uni-osnabrueck.de/virtuos/digitale-dienste/ssh-keys/-/raw/main/lars.pub
   roles:
     - role: user_setup
       delete_users: true
       admins:
-        # yamllint disable rule:line-length
-        - name: ftest
-          key: file:.test.pub
-        - name: utest
-          key: https://gitlab.uni-osnabrueck.de/virtuos/digitale-dienste/ssh-keys/-/raw/main/lars.pub
+        - *adm
         - name: ktest
           key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJD6IefLuRrBMPvXv7PVj0nIwHZIv1r/LSNRIien9dke

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ansible-galaxy collection install ansible.posix
 Have a look at the [defaults](defaults/main.yml) to see what variables you can set.
 
 You will need to specify the variable `admins` as a list of usernames and SSH keys.
-Keys can be public keys as strings, URLs or local files.
+Public keys can be specified as strings, URLs or local files.
 
 - To specify a key directly, just provide the key as string.
 - To load a key from file, prefix the path with the `file:` schema.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,17 @@
 ---
-# The list of admin user names to add on every machine.
+# The list of admin users to add on every machine.
+# Every user must have a name and a key.
+#
+# Keys can be specified as strings, URLs or local files.
+# - To specify a key directly, just provide the key as string.
+# - To load a key from file, prefix the path with the `file:` schema.
+# - To load a key from a URL, specify a URL with `http:` or `https:` schema.
+#
 # The list is flattened automatically to allow for something like:
 # admins:
 #   - *global_admins
-#   - additional_admin
+#   - name: additional_admin
+#     key: ...
 admins: []
 
 # If users not listed as admins should be deleted.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,7 +64,7 @@
       ansible.builtin.set_fact:
         old_users: >
           {{ managed_users.stdout.split(",")
-          | difference((admins | map(attribute="name") | flatten)) }}
+          | difference((admins | flatten | map(attribute="name"))) }}
       delegate_to: 127.0.0.1
       become: false
 


### PR DESCRIPTION
The role allows including a list of global admins in the list of admin users to manage. This patch fixes a problem where this wasn't working properly since the list needs to be flattened first, before accessing any attributes. This also adds a test for this and updates the documentation around this. 