### PR TITLE
Switch to `user_setup_delete_users`

### DIFF
--- a/.test/test.yml
+++ b/.test/test.yml
@@ -11,7 +11,7 @@
         key: https://gitlab.uni-osnabrueck.de/virtuos/digitale-dienste/ssh-keys/-/raw/main/lars.pub
   roles:
     - role: user_setup
-      delete_users: true
+      user_setup_delete_users: true
       admins:
         - *adm
         - name: ktest

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ An example playbook to create two admin unsers and detele all other users:
   become: true
   roles:
     - role: user_setup
-      delete_users: true
+      user_setup_delete_users: true
       admins:
         - name: foo
           key: http://example.com/foo.pub
@@ -62,9 +62,10 @@ An example playbook to create two admin unsers and detele all other users:
 
 ## Deleting Users
 
-If `delete_users` is det to `true` (default), the role will try to delete all users not in `admins`.
-Users are identified by the directories present in `/home`.
-Users with no home directory or a home directory somewhere else are not touched by this role.
+If `user_setup_delete_users` is set to `true` (default), the role will try to delete all users not in `admins`.
+Users created via this role are part of the group `managed`.
+The users being deleted are all users in the group `managed` which are not defined in `admins`.
+Users with are not in the group `managed` will not be touched by this role.
 
 
 ## License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,4 +16,4 @@ admins: []
 
 # If users not listed as admins should be deleted.
 # The script uses home directories to identify existing users.
-delete_users: true
+user_setup_delete_users: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,7 +52,7 @@
     label: '{{ item.name }}'
 
 - name: Detect and remove old users
-  when: delete_users
+  when: user_setup_delete_users
   block:
     - name: Get all managed users
       ansible.builtin.command:  # noqa command-instead-of-module


### PR DESCRIPTION
This patch switches to using `user_setup_delete_users` as variable identifying if old users should be deleted. Using the role name as prefix for variables is generally recommended.