### PR TITLE
Switch to `user_setup_admins`

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,0 @@
-exclude_paths:
-  - .test

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -16,8 +16,11 @@ jobs:
       - name: install dependencies
         run: >
           pip3 install
+          ansible
           ansible-lint
           yamllint
+
+      - run: ansible-galaxy collection install ansible.posix
 
       - run: ansible-lint
 

--- a/.test/test.yml
+++ b/.test/test.yml
@@ -12,7 +12,7 @@
   roles:
     - role: user_setup
       user_setup_delete_users: true
-      admins:
+      user_setup_admins:
         - *adm
         - name: ktest
           key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJD6IefLuRrBMPvXv7PVj0nIwHZIv1r/LSNRIien9dke

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ansible-galaxy collection install ansible.posix
 
 Have a look at the [defaults](defaults/main.yml) to see what variables you can set.
 
-You will need to specify the variable `admins` as a list of usernames and SSH keys.
+You will need to specify the variable `user_setup_admins` as a list of usernames and SSH keys.
 Public keys can be specified as strings, URLs or local files.
 
 - To specify a key directly, just provide the key as string.
@@ -23,7 +23,7 @@ Public keys can be specified as strings, URLs or local files.
 - To load a key from a URL, specify a URL with `http:` or `https:` schema.
 
 ```yaml
-admins:
+user_setup_admins:
   - name: foo
     key: http://example.com/foo.pub
   - name: bar
@@ -50,7 +50,7 @@ An example playbook to create two admin unsers and detele all other users:
   roles:
     - role: user_setup
       user_setup_delete_users: true
-      admins:
+      user_setup_admins:
         - name: foo
           key: http://example.com/foo.pub
         - name: bar
@@ -62,9 +62,9 @@ An example playbook to create two admin unsers and detele all other users:
 
 ## Deleting Users
 
-If `user_setup_delete_users` is set to `true` (default), the role will try to delete all users not in `admins`.
+If `user_setup_delete_users` is set to `true` (default), the role will try to delete all users not in `user_setup_admins`.
 Users created via this role are part of the group `managed`.
-The users being deleted are all users in the group `managed` which are not defined in `admins`.
+The users being deleted are all users in the group `managed` which are not defined in `user_setup_admins`.
 Users with are not in the group `managed` will not be touched by this role.
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,12 +8,12 @@
 # - To load a key from a URL, specify a URL with `http:` or `https:` schema.
 #
 # The list is flattened automatically to allow for something like:
-# admins:
+# user_setup_admins:
 #   - *global_admins
 #   - name: additional_admin
 #     key: ...
-admins: []
+user_setup_admins: []
 
-# If users not listed as admins should be deleted.
+# If users not listed in `user_setup_admins` should be deleted.
 # The script uses home directories to identify existing users.
 user_setup_delete_users: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Check if variables are defined
   ansible.builtin.assert:
     that:
-      - admins is truthy
+      - user_setup_admins is truthy
 
 - name: Ensure group "managed" exists
   ansible.builtin.group:
@@ -19,7 +19,7 @@
     name: '{{ item.name }}'
     groups: managed
     append: true
-  loop: '{{ admins | flatten }}'
+  loop: '{{ user_setup_admins | flatten }}'
   loop_control:
     label: '{{ item.name }}'
 
@@ -30,7 +30,7 @@
     mode: '0644'
     dest: /etc/sudoers.d/99-user_setup-{{ item.name }}
     content: '{{ item.name }} ALL=(ALL) NOPASSWD: ALL'
-  loop: '{{ admins | flatten }}'
+  loop: '{{ user_setup_admins | flatten }}'
   loop_control:
     label: '{{ item.name }}'
 
@@ -47,7 +47,7 @@
       if item.key.startswith('file:') else
       item.key
       }}
-  loop: '{{ admins | flatten }}'
+  loop: '{{ user_setup_admins | flatten }}'
   loop_control:
     label: '{{ item.name }}'
 
@@ -64,7 +64,7 @@
       ansible.builtin.set_fact:
         old_users: >
           {{ managed_users.stdout.split(",")
-          | difference((admins | flatten | map(attribute="name"))) }}
+          | difference((user_setup_admins | flatten | map(attribute="name"))) }}
       delegate_to: 127.0.0.1
       become: false
 


### PR DESCRIPTION
This patch switches to using `user_setup_admins` as variable identifying the list of users to set up. Using the role name as prefix for variables is generally recommended.